### PR TITLE
Add mirror endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Built with **Node.js** and **Express**.
 | `ALL`  | `/error/network`        | Simulates a network error by closing the connection.                 |
 | `ALL`  | `/error/malformed-json` | Returns malformed JSON response.                                     |
 | `ALL`  | `/error/error`          | Throws an unhandled exception to trigger Express error handler.      |
+| `ALL`  | `/mirror`               | Returns the request body as a response.                              |
 | `ALL`  | `/status/{status}`      | Respond with a given HTTP status code (must be between 200 and 599). |
 | `ALL`  | `/uuid`                 | Generate and return a random UUID (version 4).                       |
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,6 +1,7 @@
 import express from 'express';
 import { errorRouter } from './routes/error.js';
 import { indexRouter } from './routes/index.js';
+import { mirrorRouter } from './routes/mirror.js';
 import { statusRouter } from './routes/status.js';
 import { uuidRouter } from './routes/uuid.js';
 import { HttpStatusCodes } from './utils/http.js';
@@ -8,9 +9,11 @@ import { environment } from './env.js';
 import { log } from './logger.js';
 
 const app = express();
+app.use(express.json());
 
 app.use('/', indexRouter);
 app.use('/error', errorRouter);
+app.use('/mirror', mirrorRouter);
 app.use('/status', statusRouter);
 app.use('/uuid', uuidRouter);
 

--- a/src/routes/mirror.ts
+++ b/src/routes/mirror.ts
@@ -1,0 +1,9 @@
+import { Router } from 'express';
+
+const mirrorRouter = Router();
+
+mirrorRouter.all('/', (req, res) => {
+  res.json(req.method === 'GET' || req.body === undefined ? {} : req.body);
+});
+
+export { mirrorRouter };

--- a/tests/ut/routes/mirror.test.ts
+++ b/tests/ut/routes/mirror.test.ts
@@ -1,0 +1,37 @@
+import express from 'express';
+import request from 'supertest';
+import { mirrorRouter } from '../../../src/routes/mirror.js';
+
+const app = express();
+app.use(express.json());
+app.use('/mirror', mirrorRouter);
+
+describe('mirrorRouter', () => {
+  const testBody = { message: 'Hello' };
+
+  const httpMethods = ['post', 'put', 'delete', 'patch', 'options'] as const;
+
+  describe.each(httpMethods)('%s method', (method) => {
+    it('should return the request body as a response', async () => {
+      const response = await request(app)[method]('/mirror').send(testBody);
+      expect(response.status).toBe(200);
+      expect(response.headers['content-type']).toMatch(/application\/json/);
+      expect(response.body).toEqual(testBody);
+    });
+
+    it('should return an empty body', async () => {
+      const response = await request(app)[method]('/mirror');
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual({});
+    });
+  });
+
+  describe('get method', () => {
+    it('should return an empty body', async () => {
+      const response = await request(app).get('/mirror');
+      expect(response.status).toBe(200);
+      expect(response.text).toBe('{}');
+      expect(response.body).toEqual({});
+    });
+  });
+});


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `/mirror` API endpoint that echoes request data back to the caller, supporting all HTTP methods.

* **Tests**
  * Introduced test suite validating mirror endpoint behavior across different request methods.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->