### PR TITLE
Add shutdown endpoint and SIGTERM

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Built with **Node.js** and **Express**.
 | `ALL`  | `/error/error`          | Throws an unhandled exception to trigger Express error handler.      |
 | `ALL`  | `/mirror`               | Returns the request body as a response.                              |
 | `ALL`  | `/request`              | Returns a structured JSON dump of the incoming request.              |
+| `ALL`  | `/shutdown`             | Triggers a shutdown of the server. Requires `ENABLE_SHUTDOWN=true`.  |
 | `ALL`  | `/status/{status}`      | Respond with a given HTTP status code (must be between 200 and 599). |
 | `ALL`  | `/uuid`                 | Generate and return a random UUID (version 4).                       |
 
@@ -41,6 +42,7 @@ Built with **Node.js** and **Express**.
 | `KEEP_ALIVE_TIMEOUT` | No       | `5000`        | HTTP keep-alive timeout in milliseconds.                                                     |
 | `HEADERS_TIMEOUT`    | No       | `10000`       | HTTP headers timeout in milliseconds. Must be > `KEEP_ALIVE_TIMEOUT`.                        |
 | `REQUEST_TIMEOUT`    | No       | `30000`       | Request timeout in milliseconds. Must be > `HEADERS_TIMEOUT`.                                |
+| `ENABLE_SHUTDOWN`    | No       | `false`       | Enables the /shutdown endpoint.                                                              |
 
 ## 🚀 Build and Run the Application
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -5,6 +5,7 @@ import { errorRouter } from './routes/error.js';
 import { indexRouter } from './routes/index.js';
 import { mirrorRouter } from './routes/mirror.js';
 import { requestRouter } from './routes/request.js';
+import { shutdownRouter } from './routes/shutdown.js';
 import { statusRouter } from './routes/status.js';
 import { uuidRouter } from './routes/uuid.js';
 import { HttpStatusCodes } from './utils/http.js';
@@ -25,6 +26,7 @@ app.use('/', indexRouter);
 app.use('/error', errorRouter);
 app.use('/mirror', mirrorRouter);
 app.use('/request', requestRouter);
+app.use('/shutdown', shutdownRouter);
 app.use('/status', statusRouter);
 app.use('/uuid', uuidRouter);
 

--- a/src/env.ts
+++ b/src/env.ts
@@ -67,6 +67,7 @@ if (requestTimeout <= headersTimeout) {
 }
 
 export const environment = {
+  enableShutdown: process.env['ENABLE_SHUTDOWN'] === 'true',
   logLevel: logLevel as LogLevel,
   maxDelay,
   nodeEnv: nodeEnv as NodeEnv,

--- a/src/routes/shutdown.ts
+++ b/src/routes/shutdown.ts
@@ -1,0 +1,23 @@
+import { Router } from 'express';
+import { environment } from '../env.js';
+import { HttpStatusCodes } from '../utils/http.js';
+
+const shutdownRouter = Router();
+
+shutdownRouter.all('/', (_req, res) => {
+  if (!environment.enableShutdown) {
+    res.status(HttpStatusCodes.FORBIDDEN).json({
+      error: {
+        message: 'Shutdown is not enabled',
+      },
+    });
+    return;
+  }
+
+  res.on('finish', () => {
+    process.kill(process.pid, 'SIGTERM');
+  });
+  res.json({ message: 'Server shutting down' });
+});
+
+export { shutdownRouter };

--- a/src/server.ts
+++ b/src/server.ts
@@ -19,3 +19,33 @@ server.on('error', (err) => {
   log.error({ err }, 'Server failed to start');
   process.exit(1);
 });
+
+let isShuttingDown = false;
+
+process.on('SIGTERM', () => {
+  if (isShuttingDown) {
+    log.warn('Shutdown already in progress...');
+    return;
+  }
+  isShuttingDown = true;
+
+  log.info('SIGTERM signal received: closing HTTP server');
+
+  const forceExitTimeout = setTimeout(() => {
+    log.error('Server close timed out, forcing exit');
+    process.exit(1);
+  }, 10_000);
+
+  server.closeAllConnections();
+  server.close((err) => {
+    clearTimeout(forceExitTimeout);
+
+    if (err) {
+      log.error({ err }, 'Error during server close');
+      process.exit(1);
+    }
+
+    log.info('HTTP server closed');
+    process.exit(0);
+  });
+});

--- a/tests/ut/routes/shutdown.test.ts
+++ b/tests/ut/routes/shutdown.test.ts
@@ -1,0 +1,77 @@
+import express from 'express';
+import request from 'supertest';
+
+describe('shutdownRouter', () => {
+  let app: express.Express;
+  let mockKill: jest.SpyInstance;
+
+  const createApp = async (): Promise<express.Express> => {
+    const app = express();
+    app.use(express.json());
+
+    jest.resetModules();
+
+    jest.doMock('../../../src/env.js', () => ({
+      environment: {
+        enableShutdown: mockEnableShutdown,
+      },
+    }));
+
+    const { shutdownRouter } = await import('../../../src/routes/shutdown.js');
+    app.use('/shutdown', shutdownRouter);
+
+    return app;
+  };
+
+  let mockEnableShutdown: boolean;
+
+  beforeEach(() => {
+    mockKill = jest.spyOn(process, 'kill').mockImplementation(() => true);
+  });
+
+  afterEach(() => {
+    mockKill.mockRestore();
+  });
+
+  const httpMethods = ['get', 'post', 'put', 'delete', 'patch', 'head', 'options'] as const;
+
+  describe.each(httpMethods)('%s method', (method) => {
+    describe('when shutdown is disabled', () => {
+      beforeEach(async () => {
+        mockEnableShutdown = false;
+        app = await createApp();
+      });
+
+      it('should return 403 Forbidden', async () => {
+        const response = await request(app)[method]('/shutdown');
+        expect(response.status).toBe(403);
+        if (method !== 'head') {
+          expect(response.body).toEqual({
+            error: {
+              message: 'Shutdown is not enabled',
+            },
+          });
+        }
+        expect(mockKill).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('when shutdown is enabled', () => {
+      beforeEach(async () => {
+        mockEnableShutdown = true;
+        app = await createApp();
+      });
+
+      it('should return 200 OK and send SIGTERM', async () => {
+        const response = await request(app)[method]('/shutdown');
+        expect(response.status).toBe(200);
+        if (method !== 'head') {
+          expect(response.body).toEqual({
+            message: 'Server shutting down',
+          });
+        }
+        expect(mockKill).toHaveBeenCalledWith(process.pid, 'SIGTERM');
+      });
+    });
+  });
+});


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `/shutdown` endpoint for controlled server shutdown. Enable via `ENABLE_SHUTDOWN=true` environment variable (default: disabled).

* **Documentation**
  * Updated API reference documenting `/shutdown` endpoint, including configuration requirements and response details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->